### PR TITLE
Fix Password Authentication by Hashing Passwords Before Storage

### DIFF
--- a/pages/api/auth/[...nextauth].tsx
+++ b/pages/api/auth/[...nextauth].tsx
@@ -14,31 +14,40 @@ export default NextAuth({
         password: { label: "Password", type: "password" },
       },
       authorize: async (credentials) => {
-
         if (!credentials || !credentials.matricno || !credentials.password) {
-            console.error('Missing Credentials');
+          console.error('Missing credentials');
+          return null;
+        }
+
+        try {
+          const user = await prisma.member.findUnique({
+            where: { matricno: credentials.matricno },
+          });
+
+          if (user) {
+            const passwordMatch = bcrypt.compareSync(credentials.password, user.password);
+            if (passwordMatch) {
+              return {
+                ...user,
+                id: user.id.toString(), // Converts id to string before returning it to the user
+              };
+            } else {
+              console.error('Password does not match');
+              return null;
+            }
+          } else {
+            console.error('No user found with this matric number');
             return null;
           }
-
-        const user = await prisma.member.findUnique({
-          where: { matricno: credentials?.matricno },
-        });
-
-        if (user && bcrypt.compareSync(credentials?.password, user.password)) {
-          return {
-            ...user,
-            id: user.id.toString(),  //converts id to string before returning it to the user
-          };
-        } else {
-          console.error('Invalid credentials');
+        } catch (error) {
+          console.error('Error in authorize function:', error);
           return null;
         }
       },
     }),
   ],
   callbacks: {
-     async session({ session, user }) {
-      // Add type guards to ensure user and session.user are defined
+    async session({ session, user }) {
       if (session.user && user) {
         session.user.id = user.id;
         session.user.role = user.role;

--- a/pages/api/auth/[...nextauth].tsx
+++ b/pages/api/auth/[...nextauth].tsx
@@ -16,6 +16,7 @@ export default NextAuth({
       authorize: async (credentials) => {
 
         if (!credentials || !credentials.matricno || !credentials.password) {
+            console.error('Missing Credentials');
             return null;
           }
 
@@ -29,6 +30,7 @@ export default NextAuth({
             id: user.id.toString(),  //converts id to string before returning it to the user
           };
         } else {
+          console.error('Invalid credentials');
           return null;
         }
       },

--- a/src/app/signin/SignIn.tsx
+++ b/src/app/signin/SignIn.tsx
@@ -22,6 +22,7 @@ export default function SignIn() {
     });
 
     if (result?.error) {
+      console.error('Error during sign-in: ', result.error);
       alert(result.error);
     } else {
       // Fetch the current session data


### PR DESCRIPTION
# Description
This pull request addresses the issue where password authentication was failing due to passwords being stored in plain text rather than being hashed

## Changes

### Manual Password Hashing:
 - Since users were (temporarily) being added via Prisma Studio, manually hash passwords using bcrypt or an online tool.
 - Example bcrypt hash for `yourpassword` : ` bcrypt.hashSync('yourpassword', bcrypt.genSaltSync(10));`

### Updated NextAuth Configuration ([...nextauth].tsx):
- Added detailed logging for debugging password comparison.
- Ensured the authorization logic correctly compares hashed passwords.

Closes #20 