### PR TITLE
Add Middleware to Protect Routes Based on User Roles

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -13,12 +13,14 @@ export async function middleware(req: NextRequest) {
 
 
   if (!token) {
+    console.log('SIGN IN REQUIRED!');
     return NextResponse.redirect(new URL('/signin', req.url));
   }
 
 
   if (pathname.startsWith('/AdminDashboard')) {
     if (token.role !== 'ADMIN' && token.role !== 'SUPERADMIN') {
+      console.log('ADMIN ROLE REQUIRED!');
       return NextResponse.redirect(new URL('/UserDashboard', req.url));
     }
   }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+
+export async function middleware(req: NextRequest) {
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+
+  const { pathname } = req.nextUrl;
+
+
+  if (pathname.startsWith('/signin')) {
+    return NextResponse.next();
+  }
+
+
+  if (!token) {
+    return NextResponse.redirect(new URL('/signin', req.url));
+  }
+
+
+  if (pathname.startsWith('/AdminDashboard')) {
+    if (token.role !== 'ADMIN' && token.role !== 'SUPERADMIN') {
+      return NextResponse.redirect(new URL('/UserDashboard', req.url));
+    }
+  }
+
+//   if (pathname.startsWith('/superadmin')) {
+//     if (token.role !== 'SUPERADMIN') {
+//       return NextResponse.redirect(new URL('/UserDashboard', req.url));
+//     }
+//   }
+
+  return NextResponse.next();
+}
+
+export const config = {
+    matcher: ['/AdminDashboard/:path*', '/UserDashboard/:path*', '/signin'],
+};


### PR DESCRIPTION
This pull request sets up middleware to protect routes based on user roles. The middleware ensures that only authenticated users with the appropriate roles can access admin routes, while other users are redirected to their respective dashboards.

## Changes
### Create Middleware File (middleware.ts):
- Implemented middleware that checks if a user is authenticated and has the correct role to access admin routes.
- Redirects unauthenticated users to the sign-in page.
- Redirects users without the appropriate role to the user dashboard.

## Verification:
### Test Route Protection
- Attempt to access an admin route as an unauthenticated user and verify redirection to the sign-in page.
- Attempt to access an admin route as a user without admin privileges and verify redirection to the user dashboard.
- Verify that authenticated admin users can access admin routes.